### PR TITLE
Correcting for Sentry's new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hosted services
 - [Airbrake](https://www.airbrake.io/) - tracekit, source maps. [No automatic error capture](https://github.com/airbrake/airbrake-js/issues/82).
 - http://www.errorstack.com/
 - http://jslogger.com/
-- https://www.getsentry.com/ - source maps, tracekit
+- https://www.sentry.io/ - source maps, tracekit, breadcrumbs, [inline React error codes](https://blog.sentry.io/2016/08/10/react-minified-errors.html); [free for <150,000 events/month](https://sentry.io/pricing)
 - http://raygun.io/ - tracekit
 - https://bugsnag.com/ - source maps
 - [Rollbar](https://rollbar.com/) - can [trace errors in 3rd party scripts](https://github.com/rollbar/rollbar.js/issues/108#issuecomment-121448333) as well; [free for <5000 events/month](https://rollbar.com/pricing/); source maps


### PR DESCRIPTION
Including Sentry's features that were mentioned in other product listings (other features, like stack traces, smart grouping, and code context seem like table stakes, felt they were unnecessary to list)