### PR TITLE
Fix NewRelic Browser link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Hosted services
 - [Loggly](https://www.loggly.com/docs/javascript/) - [no stack tracing](https://github.com/loggly/loggly-jslogger/issues/24)
 - [jsErrLog](http://jserrlog.appspot.com/) - running on the free Google AppEngine
 - [Ruxit Web Monitoring](https://ruxit.com/web-monitoring/) - real user and synthetic monitoring including stacktraces, originating user action and detailed browser metrics.
-- [NewRelic Browser](https://newrelic.com/products/browser-monitoring) - JS errors, real user monitoring, AJAX request insights
+- [NewRelic Browser](https://newrelic.com/platform/browser-monitoring) - JS errors, real user monitoring, AJAX request insights
 - [AppSignal](https://appsignal.com/javascript/)
 
 Self-hosted services


### PR DESCRIPTION
I noticed the URL for NewRelic Browser has changed, and unauthenticated users are now seeing a 403 error.

```console
$ curl -sIL 'https://newrelic.com/products/browser-monitoring' | grep -E '(HTTP|location)'
HTTP/2 301
location: https://newrelic.com/node/2424
HTTP/2 403
```
